### PR TITLE
Update README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -114,7 +114,7 @@ All responses from the server are returned in the following format (for all LLM 
    ```
 2. Install the required dependencies using pip
    ```
-   pip install requirements.txt
+   pip install -r requirements.txt
    ```
 3. Set your LLM API keys
    ```


### PR DESCRIPTION
fixes the error

```
   pip install requirements.txt
ERROR: Could not find a version that satisfies the requirement requirements.txt (from versions: none)
HINT: You are attempting to install a package literally named "requirements.txt" (which cannot exist). Consider using the '-r' flag to install the packages listed in requirements.txt
ERROR: No matching distribution found for requirements.txt
```